### PR TITLE
Added option to pass in batch size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,16 +31,20 @@ require('yargs').command(
       describe: 'Automatically finish upgrades when complete',
       type: 'boolean',
       default: true,
+    }).option('batchSize', {
+      describe: 'The number of containers that you want stopped from the old service and started from the new service at one time.',
+      type: 'int',
+      default: 1,
     })
   },
-  async ({ service, image, finish }) => {
+  async ({ service, image, finish, batchSize }) => {
     log(`> Finding services with label "service=${service}"`);
     const services = await api.findServicesByTag({ service });
 
     log(`> Found ${services.length} services to upgrade.`);
     if (services.length) {
       log('> Starting service upgrades.');
-      await Promise.all(services.map(service => api.upgradeService({ service, image, finish })))
+      await Promise.all(services.map(service => api.upgradeService({ service, image, finish, batchSize })))
         .then(() => log('> Upgrades complete.'));
     }
     log('> Run completed.\n');

--- a/src/rancher.js
+++ b/src/rancher.js
@@ -43,6 +43,7 @@ class Rancher {
   async upgradeService({
     service,
     image,
+    batchSize,
     finish = false,
     startFirst = true,
   }) {
@@ -52,7 +53,7 @@ class Rancher {
     launchConfig.imageUuid = `docker:${image}`;
     const body = JSON.stringify({
       inServiceStrategy: {
-        batchSize: 1,
+        batchSize,
         intervalMillis: 2000,
         startFirst,
         launchConfig,


### PR DESCRIPTION
This allows us to set the batch size rancher will update. In the case of Platform this should reduce deployment times by 1/4th because now we can update all 4 container at once. This is also better because people will get the latest code all at about the same time.